### PR TITLE
✨Add sort by functionality

### DIFF
--- a/link.py
+++ b/link.py
@@ -278,6 +278,11 @@ class Response(web.View):
             .first()
         )
 
+        try:
+            sort_by = self.request.query['sort_by']
+        except Exception as e:
+            sort_by = ""
+
         if response:
             friend_ids = [friend.id for friend in user.all_friends]
             friend_responses = orm.query(db.Response).filter(
@@ -305,6 +310,7 @@ class Response(web.View):
                     "theirs": theirs,
                     "friends": list(friend_responses),
                     "others": list(other_responses),
+                    "sort_by": sort_by,
                 }
             else:
                 raise web.HTTPNotFound()

--- a/templates/response.mako
+++ b/templates/response.mako
@@ -1,13 +1,20 @@
 <%inherit file="base.mako"/>
 
 <div class="col-md-9">
-    <h3>Comparing answers for <a href="/survey/${survey.id}">${survey.name}</a>
+    <h3 style="display:inline">Comparing answers for <a href="/survey/${survey.id}">${survey.name}</a>
         % if theirs.privacy == "public" or theirs.privacy == "friends":
             with ${theirs.user.username}
         % else:
             with [hidden]
         % endif
     </h3>
+    <form action="/response/${theirs.id}" method="GET" style="display:inline">
+        <label for="sort_by">Sorted by: </label>
+        <select name="sort_by" onchange="javascript:document.forms[0].submit()">
+            <option value="" ${"selected" if sort_by == "" else ""}>Compatibility</option>
+            <option value="cat" ${"selected" if sort_by == "cat" else ""}>Category</option>
+        </select>
+    </form>
     <p>${survey.long_description or ""}</p>
 
     <%
@@ -32,15 +39,27 @@
                             my_answer.value_name(), my_answer.question.text,
                             their_answer.value_name(), their_answer.question.text
                         )
-                    things.append((-score, -their_answer.value, my_answer.question.order, thing))
+                    things.append((-score, -their_answer.value, my_answer.question.order, thing, my_answer.question.section))
     %>
+    <% 
+        def sort_order(row):
+            if sort_by == "cat": 
+                return (row[4], row[0], row[1], row[2])
+            else:
+                return (row[0], row[1], row[2])
+        last_section = None 
+        %>
     <ul>
-        % for score, their_score, order, thing in sorted(things):
+        % for score, their_score, order, thing, section, in sorted(things, key=sort_order):
+            % if sort_by == "cat" and last_section != section:
+                </ul><h4>${section if section else "Unsorted"}</h4><ul>
+            % endif
             % if -score == 4:
                 <li><b>${thing}</b></li>
             % else:
                 <li>${thing}</li>
             % endif
+            <% last_section = section %>
         % endfor
     </ul>
 </div>

--- a/templates/response.mako
+++ b/templates/response.mako
@@ -39,27 +39,33 @@
                             my_answer.value_name(), my_answer.question.text,
                             their_answer.value_name(), their_answer.question.text
                         )
-                    things.append((-score, -their_answer.value, my_answer.question.order, thing, my_answer.question.section))
+                    things.append({
+                        "score": -score, 
+                        "their_score": -their_answer.value, 
+                        "order": my_answer.question.order, 
+                        "thing": thing, 
+                        "section": my_answer.question.section
+                    })
     %>
     <% 
         def sort_order(row):
             if sort_by == "cat": 
-                return (row[4], row[0], row[1], row[2])
+                return (row["section"], row["score"], row["their_score"], row["order"])
             else:
-                return (row[0], row[1], row[2])
+                return (row["score"], row["their_score"], row["order"])
         last_section = None 
-        %>
+    %>
     <ul>
-        % for score, their_score, order, thing, section, in sorted(things, key=sort_order):
-            % if sort_by == "cat" and last_section != section:
-                </ul><h4>${section if section else "Unsorted"}</h4><ul>
+        % for row in sorted(things, key=sort_order):
+            % if sort_by == "cat" and last_section != row["section"]:
+                </ul><h4>${row["section"] if row["section"] else "Unsorted"}</h4><ul>
             % endif
-            % if -score == 4:
-                <li><b>${thing}</b></li>
+            % if -row["score"] == 4:
+                <li><b>${row["thing"]}</b></li>
             % else:
-                <li>${thing}</li>
+                <li>${row["thing"]}</li>
             % endif
-            <% last_section = section %>
+            <% last_section = row["section"] %>
         % endfor
     </ul>
 </div>


### PR DESCRIPTION
Added sort by functionality on the /response page
- Defaults to sorting by compatibility
- Controlled by the sort_by GET parameter
- `sort_order()` in `templates/response.mako` defines the sort order as `score, their_score, order` by default, but prepends `category` if `sort_by=cat` is set. 

![Link-Add-Sort-By](https://user-images.githubusercontent.com/1450103/155280039-29090f99-3440-4bec-a45f-6f00c3a2ec55.png)
