### PR TITLE
🖤 Dark Mode

### DIFF
--- a/static/light_dark.js
+++ b/static/light_dark.js
@@ -1,13 +1,13 @@
 function isDarkModeEnabled() {
-    return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+    return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
 }
 
-window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => { //scheme updated
-    setColorMode() 
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => { //system scheme updated
+    setColorMode();
 });
 
 function setColorMode(){
-    document.body.className = isDarkModeEnabled() ? "dark" : "light"
+    document.body.className = isDarkModeEnabled() ? "dark" : "light";
 }
 
-setColorMode() //set the color mode class as soon as the body tag is loaded
+setColorMode(); //set the color mode class as soon as the body tag is loaded

--- a/static/light_dark.js
+++ b/static/light_dark.js
@@ -1,0 +1,13 @@
+function isDarkModeEnabled() {
+    return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+}
+
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => { //scheme updated
+    setColorMode() 
+});
+
+function setColorMode(){
+    document.body.className = isDarkModeEnabled() ? "dark" : "light"
+}
+
+setColorMode() //set the color mode class as soon as the body tag is loaded

--- a/static/light_dark.js
+++ b/static/light_dark.js
@@ -1,13 +1,31 @@
 function isDarkModeEnabled() {
-    return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    theme = localStorage.getItem("theme")
+    switch(theme){
+        case "dark": return true;
+        case "light": return false;
+        default: return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    }
 }
 
 window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', event => { //system scheme updated
-    setColorMode();
+    localStorage.setItem("theme", null)
+    setTheme();
 });
 
-function setColorMode(){
-    document.body.className = isDarkModeEnabled() ? "dark" : "light";
+function setTheme(theme = null){
+    if(!theme) theme = isDarkModeEnabled() ? "dark" : "light";
+    document.body.className = theme
 }
 
-setColorMode(); //set the color mode class as soon as the body tag is loaded
+function toggleTheme(){
+    theme = localStorage.getItem("theme")
+    switch(theme){
+        case "dark": theme = "light"; break;
+        case "light": theme = "dark"; break;
+        default: theme = isDarkModeEnabled() ? "light" : "dark"
+    }
+    localStorage.setItem("theme", theme)
+    setTheme(theme)
+}
+
+setTheme(); //set the color mode class as soon as the body tag is loaded

--- a/static/script.js
+++ b/static/script.js
@@ -5,9 +5,9 @@ $(function () {
     $("#jscontrols").append($("<label><input type='checkbox' id='mark'> Highlight unresponded questions</label>"));
     $("#mark").click(function (evt) {
         if ($("#mark").is(":checked")) {
-            $("table.zebra")[0].classList.add("highlight-unmarked")
+            $("table.zebra").addClass("highlight-unmarked");
         } else {
-            $("table.zebra")[0].classList.remove("highlight-unmarked")
+            $("table.zebra").removeClass("highlight-unmarked");
         }
     });
 });

--- a/static/script.js
+++ b/static/script.js
@@ -10,4 +10,7 @@ $(function () {
             $("table.zebra").removeClass("highlight-unmarked");
         }
     });
+    $("#toggleTheme").click(function(evt){
+        toggleTheme();
+    })
 });

--- a/static/script.js
+++ b/static/script.js
@@ -5,9 +5,9 @@ $(function () {
     $("#jscontrols").append($("<label><input type='checkbox' id='mark'> Highlight unresponded questions</label>"));
     $("#mark").click(function (evt) {
         if ($("#mark").is(":checked")) {
-            $(".answer.a0").css("background", "#FFFFDD");
+            $("table.zebra")[0].classList.add("highlight-unmarked")
         } else {
-            $(".answer.a0").css("background", null);
+            $("table.zebra")[0].classList.remove("highlight-unmarked")
         }
     });
 });

--- a/static/style.css
+++ b/static/style.css
@@ -1,53 +1,57 @@
 :root{
 	--white:#FFF;
-	--gray1:#EFEFEF;
-	--gray2:#EEE;
-	--gray3:#E0E0E0;
-	--gray4:#DDD;
-	--gray5:#495057;
-	--gray6:#313539;
-	--gray7:#212529;
+	--light-gray1:#EFEFEF;
+	--light-gray2:#EEE;
+	--light-gray3:#E0E0E0;
+	--light-gray4:#DDD;
+	--gray:#495057;
+	--dark-gray1:#313539;
+	--dark-gray2:#212529;
 	--black:#000;
-	--blue: ##007bff;
-	--darkblue: #003e80;
-	--red: #dc3545;
-	--darkred: #661820;
-	--yellow: #FFD;
-	--darkyellow:#441;
+	--btn-blue: #007bff;
+	--btn-dark-blue: #003e80;
+	--btn-red: #dc3545;
+	--btn-dark-red: #661820;
+	--light-green: #DFD;
+	--dark-green: #141;
+	--light-yellow: #FFD;
+	--dark-yellow:#441;
+	--light-red: #FDD;
+	--dark-red: #411;
 }
 
 .light{
-	--body-bg: var(--gray4);
-	--main-bg: var(--gray2);
-	--text: var(--gray7);
-	--odd-row: var(--gray1);
-	--even-row: var(--gray3);
+	--body-bg: var(--light-gray4);
+	--main-bg: var(--light-gray2);
+	--text: var(--dark-gray2);
+	--odd-row: var(--light-gray1);
+	--even-row: var(--light-gray3);
 	--border: var(--black);
 	--form-bg: var(--white);
-	--form-fg: var(--gray5);
-	--submit: var(--blue);
-	--danger: var(--red);
-	--want: #DFD;
-	--will: var(--yellow);
-	--wont: #FDD;
-	--highlight: var(--yellow);
+	--form-fg: var(--gray);
+	--submit: var(--btn-blue);
+	--danger: var(--btn-red);
+	--want: var(--light-green);
+	--will: var(--light-yellow);
+	--wont: var(--light-red);
+	--highlight: var(--light-yellow);
 }
 
 .dark{
-	--body-bg: var(--gray7);
-	--main-bg: var(--gray6);
-	--text: var(--gray1);
-	--odd-row: var(--gray7);
-	--even-row: var(--gray6);
-	--border: var(--gray1);
-	--want: #141;
-	--will: var(--darkyellow);
-	--wont: #411;
+	--body-bg: var(--dark-gray2);
+	--main-bg: var(--dark-gray1);
+	--text: var(--light-gray1);
+	--odd-row: var(--dark-gray2);
+	--even-row: var(--dark-gray1);
+	--border: var(--light-gray1);
+	--want: var(--dark-green);
+	--will: var(--dark-yellow);
+	--wont: var(--dark-red);
 	--form-bg: var(--black);
 	--form-fg: var(--text);
-	--submit: var(--darkblue);
-	--danger: var(--darkred);
-	--highlight: var(--darkyellow);
+	--submit: var(--btn-dark-blue);
+	--danger: var(--btn-dark-red);
+	--highlight: var(--dark-yellow);
 }
 
 BODY {

--- a/static/style.css
+++ b/static/style.css
@@ -123,3 +123,15 @@ LABEL {
 table.highlight-unmarked .a0{
 	background-color: var(--highlight) !important;
 }
+
+.light #toggleTheme .fa-moon{
+	display: none;
+}
+
+.dark #toggleTheme .fa-sun{
+	display: none;
+}
+
+#toggleTheme{
+	cursor: pointer;
+}

--- a/static/style.css
+++ b/static/style.css
@@ -1,4 +1,59 @@
-BODY {background: #DDD;}
+:root{
+	--white:#FFF;
+	--gray1:#EFEFEF;
+	--gray2:#EEE;
+	--gray3:#E0E0E0;
+	--gray4:#DDD;
+	--gray5:#495057;
+	--gray6:#313539;
+	--gray7:#212529;
+	--black:#000;
+	--blue: ##007bff;
+	--darkblue: #003e80;
+	--red: #dc3545;
+	--darkred: #661820;
+	--yellow: #FFD;
+	--darkyellow:#441;
+}
+
+.light{
+	--body-bg: var(--gray4);
+	--main-bg: var(--gray2);
+	--text: var(--gray7);
+	--odd-row: var(--gray1);
+	--even-row: var(--gray3);
+	--border: var(--black);
+	--form-bg: var(--white);
+	--form-fg: var(--gray5);
+	--submit: var(--blue);
+	--danger: var(--red);
+	--want: #DFD;
+	--will: var(--yellow);
+	--wont: #FDD;
+	--highlight: var(--yellow);
+}
+
+.dark{
+	--body-bg: var(--gray7);
+	--main-bg: var(--gray6);
+	--text: var(--gray1);
+	--odd-row: var(--gray7);
+	--even-row: var(--gray6);
+	--border: var(--gray1);
+	--want: #141;
+	--will: var(--darkyellow);
+	--wont: #411;
+	--form-bg: var(--black);
+	--form-fg: var(--text);
+	--submit: var(--darkblue);
+	--danger: var(--darkred);
+	--highlight: var(--darkyellow);
+}
+
+BODY {
+	background: var(--body-bg);
+	color: var(--text);
+}
 
 FOOTER {
 	text-align: center;
@@ -6,8 +61,8 @@ FOOTER {
 	margin: 16px;
 }
 MAIN {
-	background: #EEE;
-	border: 1px solid black;
+	background: var(--main-bg);
+	border: 1px solid var(--border);
 	padding-bottom: 16px;
 }
 H3 {margin-top: 16px;}
@@ -17,8 +72,8 @@ TABLE.zebra TD, TABLE.zebra TH {vertical-align: middle; padding: 4px;}
 TABLE.zebra THEAD TD, TABLE.zebra THEAD TH {border-bottom: 2px solid #CCC;}
 TABLE.zebra TFOOT TD, TABLE.zebra TFOOT TH {border-top: 2px solid #CCC;}
 TABLE.zebra TR TD {border-bottom: 1px solid #DDD;}
-TABLE.zebra TR:nth-child(odd) {background: #EFEFEF;}
-TABLE.zebra TR:nth-child(even) {background: #E0E0E0;}
+TABLE.zebra TR:nth-child(odd) {background: var(--odd-row);}
+TABLE.zebra TR:nth-child(even) {background: var(--even-row);}
 
 LABEL {
 	font-weight: normal;
@@ -38,12 +93,29 @@ LABEL {
 	border-radius: 4px;
 }
 .www .want {
-	background: #DFD;
+	background: var(--want);
 }
 .www .will {
-	background: #FFD;
+	background: var(--will);
 }
 .www .wont {
-	background: #FDD;
+	background: var(--wont);
+}
+.form-control{
+	background-color: var(--form-bg);
+	color: var(--form-fg);
 }
 
+.btn-primary{
+	background-color: var(--submit);
+	border-color: var(--submit);
+}
+
+.btn-danger{
+	background-color: var(--danger);
+	border-color: var(--danger);
+}
+
+table.highlight-unmarked .a0{
+	background-color: var(--highlight) !important;
+}

--- a/templates/base.mako
+++ b/templates/base.mako
@@ -8,9 +8,11 @@
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
         <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
 		<link rel="stylesheet" href="/static/style.css">
+
 		<link rel="icon" type="image/x-icon" href="/static/favicon.ico">
 	</head>
-	<body>
+	<body class="">
+        <script language="javascript" src="/static/light_dark.js"></script>
         <nav class="navbar navbar-expand-lg navbar-dark fixed-top bg-dark" role="navigation">
             <a class="navbar-brand" href="/">Interest Link - ${heading}</a>
             <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">

--- a/templates/base.mako
+++ b/templates/base.mako
@@ -27,6 +27,7 @@
                             (${len(user.friend_requests_incoming)} pending)
                         % endif
                     </a></li>
+                    <li class="nav-item"><span class="nav-link" id="toggleTheme">Theme: <i class="fas fa-moon"></i><i class="fas fa-sun"></i></span></li>
                     <li class="nav-item"><a class="nav-link" href="/user/logout">Log Out</a></li>
                 </ul>
             % else:

--- a/templates/response.mako
+++ b/templates/response.mako
@@ -46,8 +46,7 @@
                         "thing": thing, 
                         "section": my_answer.question.section
                     })
-    %>
-    <% 
+
         def sort_order(row):
             if sort_by == "cat": 
                 return (row["section"], row["score"], row["their_score"], row["order"])


### PR DESCRIPTION
This PR adds support for dark/light themes. 

- By default, the theme will match the user's system default theme.
- The user can click the theme button in the menu to toggle between themes.
- Once the toggle is pressed, the preferred theme is saved to javascript localStorage and recalled on page load.
- The script tag is placed directly below the body tag to allow it to be the first thing to run after the body starts to load, but before other elements finish loading. This is key so there isn't any flickering between themes (i.e. flash from light to dark) on page load. 

![Interest Link - Pets - light-dark](https://user-images.githubusercontent.com/1450103/188113473-1da2d4f5-5446-4838-af31-92031da5adfb.png)
